### PR TITLE
allow the mentionRole setting to accept more than one string

### DIFF
--- a/src/data/cfg.schema.json
+++ b/src/data/cfg.schema.json
@@ -102,7 +102,7 @@
       "type": "string"
     },
     "mentionRole": {
-      "type": "string",
+      "$ref": "#/definitions/stringArray",
       "default": "none"
     },
     "pingOnBotMention": {


### PR DESCRIPTION
This is a fix copied from Dragory on the support Discord: https://discord.com/channels/621406760430731325/621406922175676417/806184696870076477

This fixes #549